### PR TITLE
Fixes: Exit code check & ignored args in shell mode

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -89,10 +89,21 @@ func (et ExecTask) Execute() (ExecResult, error) {
 		return ExecResult{}, err
 	}
 
-	fmt.Println("res: " + string(stdoutBytes))
-
-	return ExecResult{
+	res := ExecResult{
 		Stdout: string(stdoutBytes),
 		Stderr: string(stderrBytes),
-	}, nil
+	}
+
+	execErr := cmd.Wait()
+	if execErr != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			res.ExitCode = exitError.ExitCode()
+		}
+		fmt.Println("res: " + string(stderrBytes))
+		return res, execErr
+	}
+
+	fmt.Println("res: " + string(stdoutBytes))
+
+	return res, nil
 }

--- a/exec.go
+++ b/exec.go
@@ -33,13 +33,7 @@ func (et ExecTask) Execute() (ExecResult, error) {
 	var cmd *exec.Cmd
 
 	if et.Shell {
-		startArgs := strings.Split(et.Command, " ")
-		args := []string{"-c"}
-		for _, part := range startArgs {
-			args = append(args, part)
-		}
-		args = append(args)
-
+		args := []string{"-c", et.Command}
 		cmd = exec.Command("/bin/bash", args...)
 	} else {
 		if strings.Index(et.Command, " ") > 0 {


### PR DESCRIPTION
This PR includes two fixes:

Exit code is not checked and can lead to commands failing to be ignored and treated as successfully completed in k3sup. Golang has since 1.13 included new cross-platform exit code support using `cmd.Wait()`.

When shell mode is used, the command is split in args but `bash -c` is used, causing anything but the first argument to be ignored. E.g. `/bin/ls /` will result in the `/` ignored and will list only the local directory instead. 