### PR TITLE
Support hooking in a reader for stdin

### DIFF
--- a/pkg/v1/exec.go
+++ b/pkg/v1/exec.go
@@ -16,6 +16,10 @@ type ExecTask struct {
 	Env     []string
 	Cwd     string
 
+	// Stdin connect a reader to stdin for the command
+	// being executed.
+	Stdin io.Reader
+
 	// StreamStdio prints stdout and stderr directly to os.Stdout/err as
 	// the command runs.
 	StreamStdio bool
@@ -85,6 +89,9 @@ func (et ExecTask) Execute() (ExecResult, error) {
 				cmd.Env = append(cmd.Env, env)
 			}
 		}
+	}
+	if et.Stdin != nil {
+		cmd.Stdin = et.Stdin
 	}
 
 	stdoutBuff := bytes.Buffer{}

--- a/pkg/v1/exec_test.go
+++ b/pkg/v1/exec_test.go
@@ -1,6 +1,7 @@
 package execute
 
 import (
+	"bytes"
 	"os"
 	"strings"
 	"testing"
@@ -25,6 +26,49 @@ func TestExec_WithShell(t *testing.T) {
 	}
 }
 
+func TestExec_CatTransformString(t *testing.T) {
+	input := "1 line 1"
+
+	reader := bytes.NewReader([]byte(input))
+	want := "     1\t1 line 1"
+
+	task := ExecTask{Command: "cat", Shell: false, Args: []string{"-b"}, Stdin: reader}
+	res, err := task.Execute()
+	if err != nil {
+		t.Errorf(err.Error())
+		t.Fail()
+	}
+
+	if res.Stdout != want {
+		t.Errorf("want %q, got %q", want, res.Stdout)
+		t.Fail()
+	}
+}
+
+func TestExec_CatWC(t *testing.T) {
+	input := `this
+has
+four
+lines
+`
+
+	reader := bytes.NewReader([]byte(input))
+	want := "4"
+
+	task := ExecTask{Command: "wc", Shell: false, Args: []string{"-l"}, Stdin: reader}
+	res, err := task.Execute()
+	if err != nil {
+		t.Errorf(err.Error())
+		t.Fail()
+	}
+
+	got := strings.TrimSpace(res.Stdout)
+	if got != want {
+		t.Errorf("want %q, got %q", want, got)
+		t.Fail()
+	}
+}
+
 func TestExec_WithEnvVars(t *testing.T) {
 	task := ExecTask{Command: "env", Shell: false, Env: []string{"GOTEST=1", "GOTEST2=2"}}
 	res, err := task.Execute()
@@ -42,7 +86,6 @@ func TestExec_WithEnvVars(t *testing.T) {
 		t.Errorf("want env to show GOTEST2=2 since we passed that variable")
 		t.Fail()
 	}
-
 }
 
 func TestExec_WithEnvVarsInheritedFromParent(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

Support hooking in a reader for stdin

This will be used in arkade to pipe the input to kubectl apply.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in unit tests

## How are existing users impacted? What migration steps/scripts do we need?

No change.