### PR TITLE
WIP: Implement cancellation via context

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+
+on:
+  push:
+    branches:
+    - '*'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Run unit-tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
-all:
-	go test -v ./v1/
+test:
+	go test -v ./... --cover
+

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/alexellis/go-execute
 
 go 1.16
+
+require golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/v1/exec_context_test.go
+++ b/pkg/v1/exec_context_test.go
@@ -1,0 +1,103 @@
+package execute
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestExecuteWithContext_SleepInterruptedByTimeout(t *testing.T) {
+	task := ExecTask{Command: "/bin/sleep 1", Shell: true}
+	timeout := time.Millisecond * 200
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	task.Context = ctx
+
+	start := time.Now()
+	_, err := task.Execute()
+	if err == nil {
+		t.Fatalf("Expected cancellation error, but got nil")
+	}
+
+	duration := time.Since(start)
+	if duration > timeout*2 {
+		t.Fatalf("Cancellation failed, took %s, max timeout was: %s", duration, timeout*2)
+	}
+
+}
+
+func TestExecuteWithContext_SleepWithinTimeout(t *testing.T) {
+	task := ExecTask{Command: "/bin/sleep 0.1", Shell: true}
+	timeout := time.Millisecond * 500
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	task.Context = ctx
+
+	start := time.Now()
+	res, err := task.Execute()
+	if err != nil {
+		t.Errorf(err.Error())
+		t.Fail()
+	}
+
+	duration := time.Since(start)
+	if duration > timeout*2 {
+		t.Fatalf("Cancellation failed, took %s, max timeout was: %s", duration, timeout*2)
+	}
+
+	if len(res.Stdout) != 0 {
+		t.Errorf("want stdout to be empty, but got: %s", res.Stdout)
+		t.Fail()
+	}
+
+	if len(res.Stderr) != 0 {
+		t.Errorf("want empty on stderr, but got: %s", res.Stderr)
+		t.Fail()
+	}
+}
+
+func TestExecuteWithContext_Shell_BackgroundPrintsToStdout(t *testing.T) {
+	task := ExecTask{Command: "/bin/echo some data", Shell: true}
+
+	ctx := context.Background()
+	task.Context = ctx
+
+	res, err := task.Execute()
+	if err != nil {
+		t.Errorf(err.Error())
+		t.Fail()
+	}
+
+	if len(res.Stdout) == 0 {
+		t.Errorf("want stdout to have some echoed data, but got empty")
+		t.Fail()
+	}
+
+	if len(res.Stderr) != 0 {
+		t.Errorf("want empty on stderr, but got: %s", res.Stderr)
+		t.Fail()
+	}
+}
+
+func TestExecuteWithContext_StreamingPrintsStdout(t *testing.T) {
+	task := ExecTask{Command: "/bin/echo some data", Shell: true, StreamStdio: true}
+
+	ctx := context.Background()
+	task.Context = ctx
+
+	res, err := task.Execute()
+	if err != nil {
+		t.Errorf(err.Error())
+		t.Fail()
+	}
+
+	if len(res.Stdout) == 0 {
+		t.Errorf("want stdout to have some echoed data, but got empty")
+		t.Fail()
+	}
+
+	if len(res.Stderr) != 0 {
+		t.Errorf("want empty on stderr, but got: %s", res.Stderr)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

WIP: Implement cancellation via context

Execute allows a user to pass in a context with
a timeout, or a cancellation that can be used to terminate
the process.

Fixes: #10 #9

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with a couple of scenarios:

* `TestExecuteWithContext_SleepInterruptedByTimeout` - shows that a sleep process gets aborted due to a timeout
* `TestExecuteWithContext_SleepWithinTimeout` - shows that a sleep can pass with a deadline, that's generous enough for it.
* `TestExecuteWithContext_Shell_BackgroundPrintsToStdout` - uses a context, but doesn't set any kind of limits or cancellation - shows that the happy path still works as before

## How are existing users impacted? What migration steps/scripts do we need?

Existing users must update their code to include `context.TODO()` or `context.Background()`.

## Checklist:

Docs to be updated once solution is refined for merge.