### PR TITLE
fix: do not assume bash lives in /bin

### DIFF
--- a/pkg/v1/exec.go
+++ b/pkg/v1/exec.go
@@ -59,7 +59,7 @@ func (et ExecTask) Execute() (ExecResult, error) {
 
 		}
 
-		cmd = exec.Command("/bin/bash", args...)
+		cmd = exec.Command("bash", args...)
 	} else {
 		if strings.Index(et.Command, " ") > 0 {
 			parts := strings.Split(et.Command, " ")

--- a/pkg/v1/exec_test.go
+++ b/pkg/v1/exec_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestExec_WithShell(t *testing.T) {
-	task := ExecTask{Command: "/bin/ls /", Shell: true}
+	task := ExecTask{Command: "$(command -v ls) /", Shell: true}
 	res, err := task.Execute()
 	if err != nil {
 		t.Errorf(err.Error())


### PR DESCRIPTION
## Description

It's not true that bash resolves to `/bin/bash` for all systems and avoids ugly patches such as [1].
Also, fix the tests for systems where ls does not live in /bin. This actually improves the test since it makes use of shell features
(and would fail if it wasn't executed within a shell).

[1] https://github.com/NixOS/nixpkgs/blob/0011e576fb992ea9305d3c49387d09a84eadd596/pkgs/applications/networking/cluster/k3sup/default.nix#L25

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`go test ./...`

## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide: **not possible, 404**
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
