### PR TITLE
feat: Add context aware V2 API

### DIFF
--- a/pkg/v2/exec.go
+++ b/pkg/v2/exec.go
@@ -1,0 +1,156 @@
+package execute
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type ExecTask struct {
+	// Command is the command to execute. This can be the path to an executable
+	// or the executable with arguments. The arguments are detected by looking for
+	// a space.
+	//
+	// Examples:
+	//  - Just a binary executable: `/bin/ls`
+	//  - Binary executable with arguments: `/bin/ls -la /`
+	Command string
+	// Args are the arguments to pass to the command. These are ignored if the
+	// Command contains arguments.
+	Args []string
+	// Shell run the command in a bash shell.
+	// Note that the system must have `/bin/bash` installed.
+	Shell bool
+	// Env is a list of environment variables to add to the current environment,
+	// these are used to override any existing environment variables.
+	Env []string
+	// Cwd is the working directory for the command
+	Cwd string
+
+	// Stdin connect a reader to stdin for the command
+	// being executed.
+	Stdin io.Reader
+
+	// StreamStdio prints stdout and stderr directly to os.Stdout/err as
+	// the command runs.
+	StreamStdio bool
+
+	// PrintCommand prints the command before executing
+	PrintCommand bool
+}
+
+type ExecResult struct {
+	Stdout    string
+	Stderr    string
+	ExitCode  int
+	Cancelled bool
+}
+
+func (et ExecTask) Execute(ctx context.Context) (ExecResult, error) {
+	argsSt := ""
+	if len(et.Args) > 0 {
+		argsSt = strings.Join(et.Args, " ")
+	}
+
+	if et.PrintCommand {
+		fmt.Println("exec: ", et.Command, argsSt)
+	}
+
+	// don't try to run if the context is already cancelled
+	if ctx.Err() != nil {
+		return ExecResult{
+			// the exec package returns -1 for cancelled commands
+			ExitCode:  -1,
+			Cancelled: ctx.Err() == context.Canceled,
+		}, ctx.Err()
+	}
+
+	var command string
+	var commandArgs []string
+	if et.Shell {
+		command = "/bin/bash"
+		if len(et.Args) == 0 {
+			// use Split and Join to remove any extra whitespace?
+			startArgs := strings.Split(et.Command, " ")
+			script := strings.Join(startArgs, " ")
+			commandArgs = append([]string{"-c"}, script)
+
+		} else {
+			script := strings.Join(et.Args, " ")
+			commandArgs = append([]string{"-c"}, fmt.Sprintf("%s %s", et.Command, script))
+		}
+	} else {
+		if strings.Contains(et.Command, " ") {
+			parts := strings.Split(et.Command, " ")
+			command = parts[0]
+			commandArgs = parts[1:]
+		} else {
+			command = et.Command
+			commandArgs = et.Args
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, command, commandArgs...)
+	cmd.Dir = et.Cwd
+
+	if len(et.Env) > 0 {
+		overrides := map[string]bool{}
+		for _, env := range et.Env {
+			key := strings.Split(env, "=")[0]
+			overrides[key] = true
+			cmd.Env = append(cmd.Env, env)
+		}
+
+		for _, env := range os.Environ() {
+			key := strings.Split(env, "=")[0]
+
+			if _, ok := overrides[key]; !ok {
+				cmd.Env = append(cmd.Env, env)
+			}
+		}
+	}
+	if et.Stdin != nil {
+		cmd.Stdin = et.Stdin
+	}
+
+	stdoutBuff := bytes.Buffer{}
+	stderrBuff := bytes.Buffer{}
+
+	var stdoutWriters io.Writer
+	var stderrWriters io.Writer
+
+	if et.StreamStdio {
+		stdoutWriters = io.MultiWriter(os.Stdout, &stdoutBuff)
+		stderrWriters = io.MultiWriter(os.Stderr, &stderrBuff)
+	} else {
+		stdoutWriters = &stdoutBuff
+		stderrWriters = &stderrBuff
+	}
+
+	cmd.Stdout = stdoutWriters
+	cmd.Stderr = stderrWriters
+
+	startErr := cmd.Start()
+	if startErr != nil {
+		return ExecResult{}, startErr
+	}
+
+	exitCode := 0
+	execErr := cmd.Wait()
+	if execErr != nil {
+		if exitError, ok := execErr.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		}
+	}
+
+	return ExecResult{
+		Stdout:    stdoutBuff.String(),
+		Stderr:    stderrBuff.String(),
+		ExitCode:  exitCode,
+		Cancelled: ctx.Err() == context.Canceled,
+	}, ctx.Err()
+}

--- a/pkg/v2/exec_test.go
+++ b/pkg/v2/exec_test.go
@@ -1,0 +1,271 @@
+package execute
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExec_ReturnErrorForUnknownCommand(t *testing.T) {
+	ctx := context.Background()
+
+	task := ExecTask{Command: "/bin/go_execute_you_cant_find_me /"}
+	res, err := task.Execute(ctx)
+	if err == nil {
+		t.Fatalf("want error, but got nil")
+	}
+
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		t.Fatalf("want context.Canceled, but got %v", err)
+	}
+
+	// expect and empty default response
+	if res.Cancelled != false {
+		t.Fatalf("want not cancelled, but got true")
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("want exit code 0, but got %d", res.ExitCode)
+	}
+	if res.Stderr != "" {
+		t.Fatalf("want empty stderr, but got %s", res.Stderr)
+	}
+	if res.Stdout != "" {
+		t.Fatalf("want empty stdout, but got %s", res.Stdout)
+	}
+}
+
+func TestExec_ContextAlreadyCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	task := ExecTask{Command: "/bin/ls /"}
+	res, err := task.Execute(ctx)
+	if err == nil {
+		t.Fatalf("want error, but got nil")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, but got %v", err)
+	}
+
+	if res.Cancelled != true {
+		t.Fatalf("want cancelled, but got false")
+	}
+
+	if res.ExitCode != -1 {
+		t.Fatalf("want exit code -1, but got %d", res.ExitCode)
+	}
+}
+
+func TestExec_ContextCancelledDuringExecution(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.AfterFunc(time.Second, cancel)
+	}()
+
+	task := ExecTask{Command: "sleep 10"}
+	res, err := task.Execute(ctx)
+	if err == nil {
+		t.Fatalf("want error, but got nil")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, but got %v", err)
+	}
+
+	if res.Cancelled != true {
+		t.Fatalf("want cancelled, but got false")
+	}
+
+	if res.ExitCode != -1 {
+		t.Fatalf("want exit code -1, but got %d", res.ExitCode)
+	}
+}
+
+func TestExecShell_ContextCancelledDuringExecution(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.AfterFunc(time.Second, cancel)
+	}()
+
+	task := ExecTask{Command: "sleep 10", Shell: true}
+	res, err := task.Execute(ctx)
+	if err == nil {
+		t.Fatalf("want error, but got nil")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, but got %v", err)
+	}
+
+	if res.Cancelled != true {
+		t.Fatalf("want cancelled, but got false")
+	}
+
+	if res.ExitCode != -1 {
+		t.Fatalf("want exit code -1, but got %d", res.ExitCode)
+	}
+}
+
+func TestExec_WithShell(t *testing.T) {
+	ctx := context.Background()
+	task := ExecTask{Command: "/bin/ls /", Shell: true}
+	res, err := task.Execute(ctx)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if len(res.Stdout) == 0 {
+		t.Fatalf("want data, but got empty")
+	}
+
+	if len(res.Stderr) != 0 {
+		t.Fatalf("want empty, but got: %s", res.Stderr)
+	}
+}
+
+func TestExec_WithShellAndArgs(t *testing.T) {
+	ctx := context.Background()
+	task := ExecTask{Command: "/bin/ls", Args: []string{"/"}, Shell: true}
+	res, err := task.Execute(ctx)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if len(res.Stdout) == 0 {
+		t.Fatalf("want data, but got empty")
+	}
+
+	if len(res.Stderr) != 0 {
+		t.Fatalf("want empty, but got: %s", res.Stderr)
+	}
+}
+
+func TestExec_CatTransformString(t *testing.T) {
+	input := "1 line 1"
+
+	reader := bytes.NewReader([]byte(input))
+	want := "     1\t1 line 1"
+
+	ctx := context.Background()
+	task := ExecTask{Command: "cat", Shell: false, Args: []string{"-b"}, Stdin: reader}
+	res, err := task.Execute(ctx)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if res.Stdout != want {
+		t.Fatalf("want %q, got %q", want, res.Stdout)
+	}
+}
+
+func TestExec_CatWC(t *testing.T) {
+	input := `this
+has
+four
+lines
+`
+
+	reader := bytes.NewReader([]byte(input))
+	want := "4"
+
+	ctx := context.Background()
+	task := ExecTask{Command: "wc", Shell: false, Args: []string{"-l"}, Stdin: reader}
+	res, err := task.Execute(ctx)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	got := strings.TrimSpace(res.Stdout)
+	if got != want {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+}
+
+func TestExec_WithEnvVars(t *testing.T) {
+	ctx := context.Background()
+	task := ExecTask{Command: "env", Shell: false, Env: []string{"GOTEST=1", "GOTEST2=2"}}
+	res, err := task.Execute(ctx)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !strings.Contains(res.Stdout, "GOTEST") {
+		t.Fatalf("want env to show GOTEST=1 since we passed that variable")
+	}
+
+	if !strings.Contains(res.Stdout, "GOTEST2") {
+		t.Fatalf("want env to show GOTEST2=2 since we passed that variable")
+	}
+}
+
+func TestExec_WithEnvVarsInheritedFromParent(t *testing.T) {
+	os.Setenv("TEST", "value")
+	ctx := context.Background()
+	task := ExecTask{Command: "env", Shell: false, Env: []string{"GOTEST=1"}}
+	res, err := task.Execute(ctx)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !strings.Contains(res.Stdout, "TEST") {
+		t.Fatalf("want env to show TEST=value since we passed that variable")
+	}
+
+	if !strings.Contains(res.Stdout, "GOTEST") {
+		t.Fatalf("want env to show GOTEST=1 since we passed that variable")
+	}
+}
+
+func TestExec_WithEnvVarsAndShell(t *testing.T) {
+	ctx := context.Background()
+	task := ExecTask{Command: "env", Shell: true, Env: []string{"GOTEST=1"}}
+	res, err := task.Execute(ctx)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !strings.Contains(res.Stdout, "GOTEST") {
+		t.Fatalf("want env to show GOTEST=1 since we passed that variable")
+	}
+}
+
+func TestExec_CanStreamStdout(t *testing.T) {
+	input := "1 line 1"
+
+	reader := bytes.NewReader([]byte(input))
+	want := "     1\t1 line 1"
+
+	ctx := context.Background()
+	task := ExecTask{Command: "cat", Shell: false, Args: []string{"-b"}, Stdin: reader, StreamStdio: true}
+	res, err := task.Execute(ctx)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if res.Stdout != want {
+		t.Fatalf("want %q, got %q", want, res.Stdout)
+	}
+}
+
+func TestExec_CanStreamStderr(t *testing.T) {
+	ctx := context.Background()
+	task := ExecTask{Command: "ls /unknown/location/should/fail", StreamStdio: true}
+	res, err := task.Execute(ctx)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if res.Stdout != "" {
+		t.Fatalf("want empty string Stdout, got %q", res.Stdout)
+	}
+
+	want := "ls: cannot access '/unknown/location/should/fail': No such file or directory\n"
+	if res.Stderr != want {
+		t.Fatalf("want %q Stderr, got %q", want, res.Stderr)
+	}
+}


### PR DESCRIPTION
This new v2 module requires context, so that cancellation can be propagated correctly to sub-commands. This enables cancelling sub-command (#10) and adding timeouts (solving #9) via `context.WithTimeout`

Some additional streamlining of the code to reduce the number of `exec.Execute` calls.

The new behavior is covered by additional tests and the package should have 98% coverage.

Closes https://github.com/alexellis/go-execute/pull/11
Resolves #9 
Resolves #10 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Additional unit tests cover the new use cases.

## How are existing users impacted? What migration steps/scripts do we need?
New users would need to change their import to use the new API.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
