### PR TITLE
feat: allow redirection of command IO to user supplied writers

### DIFF
--- a/pkg/v2/exec_test.go
+++ b/pkg/v2/exec_test.go
@@ -10,6 +10,58 @@ import (
 	"time"
 )
 
+func TestExec_IsStringer(t *testing.T) {
+	cases := []struct {
+		name string
+		task ExecTask
+		want string
+	}{
+		{
+			name: "command without args",
+			task: ExecTask{Command: "/bin/ls"},
+			want: "/bin/ls",
+		},
+		{
+			name: "single command string",
+			task: ExecTask{Command: "/bin/ls /"},
+			want: "/bin/ls /",
+		},
+		{
+			name: "single command with default shell",
+			task: ExecTask{Command: "ls /", Shell: true},
+			want: "/bin/bash -c ls /",
+		},
+		{
+			name: "single command with custom shell",
+			task: ExecTask{Command: "ls /", Shell: true, ShallPath: "/bin/sh"},
+			want: "/bin/sh -c ls /",
+		},
+		{
+			name: "single command with args",
+			task: ExecTask{Command: "ls", Args: []string{"/"}},
+			want: "ls /",
+		},
+		{
+			name: "single command with args and default shell",
+			task: ExecTask{Command: "ls", Args: []string{"/"}, Shell: true},
+			want: "/bin/bash -c ls /",
+		},
+		{
+			name: "single command with args and custom shell",
+			task: ExecTask{Command: "ls", Args: []string{"/"}, Shell: true, ShallPath: "/bin/sh"},
+			want: "/bin/sh -c ls /",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.task.String() != tc.want {
+				t.Fatalf("want %s, but got %s", tc.want, tc.task.String())
+			}
+		})
+	}
+}
+
 func TestExec_ReturnErrorForUnknownCommand(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Allow the user to redirect the stdout and stderr to their own Writers. This can be useful for advanced streaming or parsing cases.

feat: Allow overriding the shell command

When using `Shell=true` the user can now define a custom `ShellPath`. When `ShellPath` is empty, the default `/bin/bash` will be used.

chore: Make the ExecTask a Stringer

Add the String() method so that the task can be easily printed. This will use the same command construction logic, thus showing the shell, command, and args that will be used.

chore: expose EnvVars method for easier debugging.

Add EnvVars() method, which allows the caller to see the envvars that will be used when the command is executed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The additional stringer test cases cover the new ShellPath behavior. 

Manual testing verifies the new IO behavior. 


## How are existing users impacted? What migration steps/scripts do we need?
These changes should all be backwards compatible, no migration steps should be needed. 


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
