### PR TITLE
Allow for spaces in command

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -15,9 +15,7 @@ type ExecTask struct {
 	// or the executable with arguments. The arguments are detected by looking for
 	// a space.
 	//
-	// Examples:
-	//  - Just a binary executable: `/bin/ls`
-	//  - Binary executable with arguments: `/bin/ls -la /`
+	// Any arguments must be given via Args
 	Command string
 
 	// Args are the arguments to pass to the command. These are ignored if the
@@ -110,14 +108,18 @@ func (et ExecTask) Execute(ctx context.Context) (ExecResult, error) {
 			commandArgs = append([]string{"-c"}, fmt.Sprintf("%s %s", et.Command, script))
 		}
 	} else {
-		if strings.Contains(et.Command, " ") {
-			parts := strings.Split(et.Command, " ")
-			command = parts[0]
-			commandArgs = parts[1:]
-		} else {
-			command = et.Command
-			commandArgs = et.Args
-		}
+
+		command = et.Command
+		commandArgs = et.Args
+
+		// AE: This had to be removed to fix: #117 where Windows users
+		// have spaces in their paths, which are misinterpreted as
+		// arguments for the command.
+		// if strings.Contains(et.Command, " ") {
+		// 	parts := strings.Split(et.Command, " ")
+		// 	command = parts[0]
+		// 	commandArgs = parts[1:]
+		// }
 	}
 
 	cmd := exec.CommandContext(ctx, command, commandArgs...)

--- a/exec_unix_test.go
+++ b/exec_unix_test.go
@@ -1,0 +1,43 @@
+//go:build linux || darwin
+
+package execute
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+)
+
+func Test_Exec_WithSpaceInCommandPath(t *testing.T) {
+
+	tmp, err := os.MkdirTemp(os.TempDir(), "exec test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(tmp)
+
+	// copy /bin/echo to a new path with a space in it
+
+	data, err := os.ReadFile("/bin/echo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newPath := path.Join(tmp, "echo")
+	if err := os.WriteFile(newPath, data, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	task := ExecTask{Command: newPath, Args: []string{"hello world"}}
+
+	res, err := task.Execute(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Stdout != "hello world\n" {
+		t.Fatalf("want %q, got %q", "hello world\n", res.Stdout)
+	}
+}


### PR DESCRIPTION
## Description

Allow for spaces in command for Windows users

Prior to this change, Windows users who had a space in the path to a command would encounter errors.

## How Has This Been Tested?

Tested with a unit test which failed before commenting out code in exec.go to split out the command and arguments if a space was within the command.

Before making the change:

```
go test -timeout 30s -run ^Test_Exec_WithSpaceInCommandPath$ github.com/alexellis/go-execute/v2 -v
=== RUN   Test_Exec_WithSpaceInCommandPath
    exec_unix_test.go:37: fork/exec /tmp/exec: no such file or directory
--- FAIL: Test_Exec_WithSpaceInCommandPath (0.00s)
FAIL
FAIL    github.com/alexellis/go-execute/v2      0.003s
FAIL
```

## How are existing users impacted? What migration steps/scripts do we need?

This is a breaking change and downstream users should make sure they populate Command and Args separately.

https://github.com/alexellis/arkade/issues/117

## Checklist:

I have:

- [x] added unit tests
