### PR TITLE
docs: add missing context to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This example captures the values from stdout and stderr without relaying to the 
 package main
 
 import (
+	"context"
 	"fmt"
 
 	execute "github.com/alexellis/go-execute/v2"
@@ -69,7 +70,8 @@ func main() {
 		StreamStdio: false,
 	}
 
-	res, err := cmd.Execute()
+	ctx := context.Background()
+	res, err := cmd.Execute(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -89,6 +91,7 @@ func main() {
 package main
 
 import (
+	"context"
 	"fmt"
 
 	execute "github.com/alexellis/go-execute/v2"
@@ -100,7 +103,9 @@ func main() {
 		Args:    []string{"-l"},
 		Shell:   true,
 	}
-	res, err := ls.Execute()
+
+	ctx := context.Background()
+	res, err := ls.Execute(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -115,6 +120,7 @@ func main() {
 package main
 
 import (
+	"context"
 	"fmt"
 
 	execute "github.com/alexellis/go-execute/v2"
@@ -125,7 +131,9 @@ func main() {
 		Command: "exit 1",
 		Shell:   true,
 	}
-	res, err := ls.Execute()
+
+	ctx := context.Background()
+	res, err := ls.Execute(ctx)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Description

The context arg was introduced in v2 but the examples were not updated.


## How Has This Been Tested?

N/A

## How are existing users impacted? What migration steps/scripts do we need?

No impact

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [x] added unit tests

---

Notes::

- the contributing doc link is a 404.
- I did the commit via github, dunno if it is signed. Feel free to redo if you need that.