### PR TITLE
feat: return error object from executed command

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -59,6 +59,7 @@ type ExecTask struct {
 type ExecResult struct {
 	Stdout    string
 	Stderr    string
+	Error     error
 	ExitCode  int
 	Cancelled bool
 }
@@ -187,6 +188,7 @@ func (et ExecTask) Execute(ctx context.Context) (ExecResult, error) {
 	return ExecResult{
 		Stdout:    stdoutBuff.String(),
 		Stderr:    stderrBuff.String(),
+		Error:     execErr,
 		ExitCode:  exitCode,
 		Cancelled: ctx.Err() == context.Canceled,
 	}, ctx.Err()

--- a/exec_test.go
+++ b/exec_test.go
@@ -27,6 +27,9 @@ func TestExec_ReturnErrorForUnknownCommand(t *testing.T) {
 	if res.Cancelled != false {
 		t.Fatalf("want not cancelled, but got true")
 	}
+	if res.Error != nil {
+		t.Fatalf("want nil error, but got %s", err.Error())
+	}
 	if res.ExitCode != 0 {
 		t.Fatalf("want exit code 0, but got %d", res.ExitCode)
 	}
@@ -56,6 +59,10 @@ func TestExec_ContextAlreadyCancelled(t *testing.T) {
 		t.Fatalf("want cancelled, but got false")
 	}
 
+	if res.Error == nil {
+		t.Fatalf("want non-nil error, but got nil")
+	}
+
 	if res.ExitCode != -1 {
 		t.Fatalf("want exit code -1, but got %d", res.ExitCode)
 	}
@@ -81,6 +88,10 @@ func TestExec_ContextCancelledDuringExecution(t *testing.T) {
 		t.Fatalf("want cancelled, but got false")
 	}
 
+	if res.Error == nil {
+		t.Fatalf("want non-nil error, but got nil")
+	}
+
 	if res.ExitCode != -1 {
 		t.Fatalf("want exit code -1, but got %d", res.ExitCode)
 	}
@@ -104,6 +115,10 @@ func TestExecShell_ContextCancelledDuringExecution(t *testing.T) {
 
 	if res.Cancelled != true {
 		t.Fatalf("want cancelled, but got false")
+	}
+
+	if res.Error == nil {
+		t.Fatalf("want non-nil error, but got nil")
 	}
 
 	if res.ExitCode != -1 {


### PR DESCRIPTION
## Description

This is tracked as part of the ExecResult as it might otherwise be shadowed by ctx.Err().

I was seeing the following error that was otherwise swallowed by the execution due to where it was returning:

```
fork/exec /tmp/sample3357583376: text file busy
```

Note: the file in question wasn't being properly written/closed before being executed, hence the error message. It took me a while to figure that out.

Closes #20

## How Has This Been Tested?

I wrote some tests.

## How are existing users impacted? What migration steps/scripts do we need?

This adds a new field so should be mostly backwards compatible

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests

---

Aside, should the contributing docs point at the inlets one?
